### PR TITLE
feat: 添加娜娜莉队自动战斗脚本并补充定向切人能力

### DIFF
--- a/src/char/BaseChar.py
+++ b/src/char/BaseChar.py
@@ -141,7 +141,7 @@ class BaseChar:
             self.logger.warning(
                 f"queued switch target not found or failed, fallback to switch_next_char: {queued_switch_builtin_key}"
             )
-        self.switch_next_char()
+        self.switch_next_char(free_intro=queued_switch_free_intro)
 
     def wait_intro(self, time_out=1.2, click=True):
         """等待角色入场动画结束。
@@ -237,6 +237,7 @@ class BaseChar:
         )
 
     def queue_switch_to_builtin_char(self, builtin_key: str, free_intro: bool = False):
+        """在本轮动作结束后排队切换到指定内置角色。"""
         self.queued_switch_builtin_key = builtin_key
         self.queued_switch_free_intro = free_intro
 
@@ -361,6 +362,7 @@ class BaseChar:
         )
 
     def hold_skill(self, duration=1.0, after_sleep=0.05):
+        """长按技能键一段时间。"""
         if not self.skill_available():
             self.logger.debug("hold_skill skipped because skill is not available")
             return False
@@ -653,6 +655,7 @@ class BaseChar:
         time_out: float = 15.0,
         after_sleep: float = 0,
     ) -> bool:
+        """持续普攻直到条件成立或超时。"""
         start = time.time()
         while time.time() - start < time_out:
             if condition():

--- a/src/char/BaseChar.py
+++ b/src/char/BaseChar.py
@@ -85,6 +85,8 @@ class BaseChar:
         self.cycle_start_time = 0.0
         self.combo_label = "default"
         self.element = Element.DEFAULT
+        self.queued_switch_builtin_key = None
+        self.queued_switch_free_intro = False
 
     def cycle_start(self):
         self.cycle_start_time = time.time()
@@ -126,6 +128,19 @@ class BaseChar:
         else:
             self.do_perform()
         self.logger.debug(f"set current char false {self.index}")
+        queued_switch_builtin_key = self.queued_switch_builtin_key
+        queued_switch_free_intro = self.queued_switch_free_intro
+        self.queued_switch_builtin_key = None
+        self.queued_switch_free_intro = False
+        if queued_switch_builtin_key:
+            switched = self.task.switch_to_builtin_char(
+                self, queued_switch_builtin_key, free_intro=queued_switch_free_intro
+            )
+            if switched:
+                return
+            self.logger.warning(
+                f"queued switch target not found or failed, fallback to switch_next_char: {queued_switch_builtin_key}"
+            )
         self.switch_next_char()
 
     def wait_intro(self, time_out=1.2, click=True):
@@ -220,6 +235,10 @@ class BaseChar:
         self.task.switch_next_char(
             self, post_action=post_action, free_intro=free_intro
         )
+
+    def queue_switch_to_builtin_char(self, builtin_key: str, free_intro: bool = False):
+        self.queued_switch_builtin_key = builtin_key
+        self.queued_switch_free_intro = free_intro
 
     def sleep(self, sec, check_combat=True):
         if not check_combat:
@@ -341,6 +360,15 @@ class BaseChar:
             self.get_skill_key(), interval=interval, down_time=down_time, after_sleep=after_sleep
         )
 
+    def hold_skill(self, duration=1.0, after_sleep=0.05):
+        if not self.skill_available():
+            self.logger.debug("hold_skill skipped because skill is not available")
+            return False
+        self.send_skill_key(down_time=duration)
+        if after_sleep > 0:
+            self.sleep(after_sleep)
+        return True
+
     def send_arc_key(self, after_sleep=0, interval=-1, down_time=0.01):
         """发送弧盘技能的按键。
 
@@ -375,6 +403,8 @@ class BaseChar:
         self.has_intro = False
         self._ultimate_available = False
         self._skill_available = False
+        self.queued_switch_builtin_key = None
+        self.queued_switch_free_intro = False
 
     def click_ultimate(self, send_click=False, wait_if_cd_ready=0.1):
         """尝试释放终结技。
@@ -615,6 +645,23 @@ class BaseChar:
             self.click()
             self.sleep(interval)
         self.sleep(after_sleep)
+
+    def continues_normal_attack_until(
+        self,
+        condition,
+        interval: float = 0.1,
+        time_out: float = 15.0,
+        after_sleep: float = 0,
+    ) -> bool:
+        start = time.time()
+        while time.time() - start < time_out:
+            if condition():
+                self.sleep(after_sleep)
+                return True
+            self.click()
+            self.sleep(interval)
+        self.sleep(after_sleep)
+        return condition()
 
     def continues_click(self, key, duration, interval=0.1):
         """持续发送指定按键一段时间。

--- a/src/char/CharFactory.py
+++ b/src/char/CharFactory.py
@@ -5,6 +5,10 @@ from typing_extensions import Any
 
 from src.char.BaseChar import BaseChar
 from src.char.Mint import Mint
+from src.char.NanallyTeamJiuyuan import NanallyTeamJiuyuan
+from src.char.NanallyTeamNanally import NanallyTeamNanally
+from src.char.NanallyTeamSakiri import NanallyTeamSakiri
+from src.char.NanallyTeamZero import NanallyTeamZero
 from src.char.Zero import Zero
 
 if TYPE_CHECKING:
@@ -18,6 +22,22 @@ char_dict: dict[str, dict[str, Any]] = {
     "char_default": {"cls": BaseChar},
     "char_zero": {"cls": Zero, "cn_name": "零"},
     "char_mint": {"cls": Mint, "cn_name": "薄荷"},
+    "char_nanally_team_nanally": {
+        "cls": NanallyTeamNanally,
+        "cn_name": "娜娜莉队-娜娜莉",
+    },
+    "char_nanally_team_zero": {
+        "cls": NanallyTeamZero,
+        "cn_name": "娜娜莉队-零",
+    },
+    "char_nanally_team_jiuyuan": {
+        "cls": NanallyTeamJiuyuan,
+        "cn_name": "娜娜莉队-九原",
+    },
+    "char_nanally_team_sakiri": {
+        "cls": NanallyTeamSakiri,
+        "cn_name": "娜娜莉队-早雾",
+    },
 }
 
 char_names = char_dict.keys()

--- a/src/char/NanallyTeamJiuyuan.py
+++ b/src/char/NanallyTeamJiuyuan.py
@@ -1,0 +1,12 @@
+from src.char.BaseChar import BaseChar
+
+
+class NanallyTeamJiuyuan(BaseChar):
+    HEAVY_ATTACK_DURATION = 3
+    NEXT_BUILTIN_KEY = "char_nanally_team_zero"
+
+    def do_perform(self):
+        self.click_ultimate()
+        self.click_skill()
+        self.heavy_attack(self.HEAVY_ATTACK_DURATION)
+        self.queue_switch_to_builtin_char(self.NEXT_BUILTIN_KEY)

--- a/src/char/NanallyTeamJiuyuan.py
+++ b/src/char/NanallyTeamJiuyuan.py
@@ -2,10 +2,13 @@ from src.char.BaseChar import BaseChar
 
 
 class NanallyTeamJiuyuan(BaseChar):
-    HEAVY_ATTACK_DURATION = 3
+    """娜娜莉队中的九原固定轮转脚本。"""
+
+    HEAVY_ATTACK_DURATION = 2.5
     NEXT_BUILTIN_KEY = "char_nanally_team_zero"
 
     def do_perform(self):
+        """执行九原的固定输出循环后切到零。"""
         self.click_ultimate()
         self.click_skill()
         self.heavy_attack(self.HEAVY_ATTACK_DURATION)

--- a/src/char/NanallyTeamNanally.py
+++ b/src/char/NanallyTeamNanally.py
@@ -1,0 +1,39 @@
+import time
+
+from src.char.BaseChar import BaseChar
+
+
+class NanallyTeamNanally(BaseChar):
+    SKILL_WAIT_TIMEOUT = 10.0
+    SKILL_MIN_DURATION = 10.0
+    CYCLE_WAIT_TIMEOUT = 30.0
+    ATTACK_INTERVAL = 0.1
+    NEXT_BUILTIN_KEY = "char_nanally_team_sakiri"
+
+    def do_perform(self):
+        if not self.skill_available():
+            self.continues_normal_attack_until(
+                self.skill_available,
+                time_out=self.SKILL_WAIT_TIMEOUT,
+            )
+
+        self.click_skill()
+        skill_start = time.time()
+
+        while True:
+            elapsed = self.time_elapsed_accounting_for_freeze(skill_start)
+            cycle_full = self.is_cycle_full()
+            if elapsed >= self.SKILL_MIN_DURATION and cycle_full:
+                break
+            if elapsed >= self.CYCLE_WAIT_TIMEOUT:
+                self.logger.warning(
+                    "NanallyTeamNanally wait cycle full timed out, fallback to switch"
+                )
+                break
+            if self.ultimate_available():
+                self.click_ultimate()
+                continue
+            self.click()
+            self.sleep(self.ATTACK_INTERVAL)
+
+        self.queue_switch_to_builtin_char(self.NEXT_BUILTIN_KEY)

--- a/src/char/NanallyTeamNanally.py
+++ b/src/char/NanallyTeamNanally.py
@@ -4,20 +4,34 @@ from src.char.BaseChar import BaseChar
 
 
 class NanallyTeamNanally(BaseChar):
-    SKILL_WAIT_TIMEOUT = 10.0
-    SKILL_MIN_DURATION = 10.0
+    """娜娜莉队中的娜娜莉固定轮转脚本。"""
+
+    SKILL_WAIT_TIMEOUT = 12.0
+    SKILL_MIN_DURATION = 12.0
     CYCLE_WAIT_TIMEOUT = 30.0
     ATTACK_INTERVAL = 0.1
     NEXT_BUILTIN_KEY = "char_nanally_team_sakiri"
 
     def do_perform(self):
-        if not self.skill_available():
-            self.continues_normal_attack_until(
+        """执行娜娜莉的站场循环，满足条件后切到早雾。"""
+        skill_ready = self.skill_available()
+        if not skill_ready:
+            skill_ready = self.continues_normal_attack_until(
                 self.skill_available,
                 time_out=self.SKILL_WAIT_TIMEOUT,
             )
 
-        self.click_skill()
+        if not skill_ready:
+            self.logger.warning("NanallyTeamNanally skill wait timed out, fallback to switch")
+            self.queue_switch_to_builtin_char(self.NEXT_BUILTIN_KEY)
+            return
+
+        clicked, _, _ = self.click_skill()
+        if not clicked:
+            self.logger.warning("NanallyTeamNanally failed to activate skill, fallback to switch")
+            self.queue_switch_to_builtin_char(self.NEXT_BUILTIN_KEY)
+            return
+
         skill_start = time.time()
 
         while True:

--- a/src/char/NanallyTeamSakiri.py
+++ b/src/char/NanallyTeamSakiri.py
@@ -2,11 +2,14 @@ from src.char.BaseChar import BaseChar
 
 
 class NanallyTeamSakiri(BaseChar):
+    """娜娜莉队中的早雾固定轮转脚本。"""
+
     HOLD_SKILL_DURATION = 2.0
     INTRO_WAIT_DURATION = 2.0
     NEXT_BUILTIN_KEY = "char_nanally_team_jiuyuan"
 
     def do_perform(self):
+        """执行早雾的固定输出循环后切到九原。"""
         if self.has_intro:
             self.sleep(self.INTRO_WAIT_DURATION)
         self.click_ultimate()

--- a/src/char/NanallyTeamSakiri.py
+++ b/src/char/NanallyTeamSakiri.py
@@ -1,0 +1,14 @@
+from src.char.BaseChar import BaseChar
+
+
+class NanallyTeamSakiri(BaseChar):
+    HOLD_SKILL_DURATION = 2.0
+    INTRO_WAIT_DURATION = 2.0
+    NEXT_BUILTIN_KEY = "char_nanally_team_jiuyuan"
+
+    def do_perform(self):
+        if self.has_intro:
+            self.sleep(self.INTRO_WAIT_DURATION)
+        self.click_ultimate()
+        self.hold_skill(self.HOLD_SKILL_DURATION)
+        self.queue_switch_to_builtin_char(self.NEXT_BUILTIN_KEY)

--- a/src/char/NanallyTeamZero.py
+++ b/src/char/NanallyTeamZero.py
@@ -2,9 +2,12 @@ from src.char.BaseChar import BaseChar
 
 
 class NanallyTeamZero(BaseChar):
+    """娜娜莉队中的零固定轮转脚本。"""
+
     NEXT_BUILTIN_KEY = "char_nanally_team_nanally"
 
     def do_perform(self):
+        """执行零的固定输出循环后切到娜娜莉。"""
         self.click_ultimate()
         self.click_skill()
         self.queue_switch_to_builtin_char(self.NEXT_BUILTIN_KEY)

--- a/src/char/NanallyTeamZero.py
+++ b/src/char/NanallyTeamZero.py
@@ -1,0 +1,10 @@
+from src.char.BaseChar import BaseChar
+
+
+class NanallyTeamZero(BaseChar):
+    NEXT_BUILTIN_KEY = "char_nanally_team_nanally"
+
+    def do_perform(self):
+        self.click_ultimate()
+        self.click_skill()
+        self.queue_switch_to_builtin_char(self.NEXT_BUILTIN_KEY)

--- a/src/combat/BaseCombatTask.py
+++ b/src/combat/BaseCombatTask.py
@@ -506,6 +506,7 @@ class BaseCombatTask(CombatCheck):
                 return char
 
     def get_char_by_builtin_key(self, builtin_key: str):
+        """根据内置角色 key 查找当前队伍中的角色实例。"""
         for char in self.chars:
             if char and getattr(char, "builtin_key", None) == builtin_key:
                 return char
@@ -520,6 +521,7 @@ class BaseCombatTask(CombatCheck):
         allow_dynamic_intro_update: bool = True,
         free_intro: bool = False,
     ) -> bool:
+        """执行一次切人流程，并在需要时动态更新目标。"""
         if switch_to is None or switch_to == current_char:
             logger.warning(f"{current_char} failed to find a valid switch target")
             return False
@@ -564,6 +566,7 @@ class BaseCombatTask(CombatCheck):
                     switch_to = new_switch_to
                     has_intro = new_has_intro
                     switch_to.has_intro = True
+                    self.has_char_slot_changed(switch_to.index, reset_char_slot=True)
                     logger.info(
                         f"switch_next_char updated target to {switch_to} has_intro {switch_to.has_intro}"
                     )
@@ -608,6 +611,7 @@ class BaseCombatTask(CombatCheck):
         post_action=None,
         free_intro: bool = False,
     ) -> bool:
+        """切换到指定角色实例。"""
         if self.team_size <= 1:
             self.click(interval=0.1)
             return False
@@ -630,6 +634,7 @@ class BaseCombatTask(CombatCheck):
         post_action=None,
         free_intro: bool = False,
     ) -> bool:
+        """切换到指定内置角色 key 对应的队友。"""
         target_char = self.get_char_by_builtin_key(builtin_key)
         if target_char is None:
             logger.warning(f"switch_to_builtin_char target not found: {builtin_key}")

--- a/src/combat/BaseCombatTask.py
+++ b/src/combat/BaseCombatTask.py
@@ -357,7 +357,7 @@ class BaseCombatTask(CombatCheck):
         """
         if self.team_size <= 1:
             self.click(interval=0.1)
-            return
+            return False
 
         current_char.wait_switch_cd()
 
@@ -383,85 +383,16 @@ class BaseCombatTask(CombatCheck):
 
         if switch_to is None or switch_to == current_char:
             logger.warning(f"{current_char} failed to find a valid switch target")
-            return
+            return False
 
-        switch_to.has_intro = has_intro
-        logger.info(
-            f"switch_next_char {current_char} -> {switch_to} has_intro {switch_to.has_intro}"
+        return self._perform_switch(
+            current_char,
+            switch_to,
+            has_intro,
+            post_action=post_action,
+            allow_dynamic_intro_update=True,
+            free_intro=free_intro,
         )
-
-        last_click_time = 0.0
-        last_decide_time = 0.0
-        start_time = time.time()
-        self.has_char_slot_changed(switch_to.index, reset_char_slot=True)
-
-        while True:
-            self.check_combat()
-            current_time = time.time()
-
-            is_char_switched = self.has_char_slot_changed(switch_to.index)
-
-            if not is_char_switched:
-                self.click(interval=0.2)
-            else:
-                self.in_ultimate = False
-                current_char.switch_out()
-                switch_to.is_current_char = True
-                if has_intro:
-                    current_char.last_outro_time = time.time()
-                break
-
-            if not is_char_switched and not has_intro and current_time - last_decide_time > 0.12:
-                last_decide_time = current_time
-                new_switch_to, new_has_intro = self._decide_switch_to(
-                    current_char, free_intro, require_intro=True
-                )
-                if new_has_intro and new_switch_to != current_char:
-                    switch_to = new_switch_to
-                    has_intro = new_has_intro
-                    switch_to.has_intro = True
-                    logger.info(
-                        f"switch_next_char updated target to {switch_to} has_intro {switch_to.has_intro}"
-                    )
-
-            if not self.is_in_team():
-                logger.info(
-                    f"not in world while switching chars_{current_char}_to_{switch_to} {current_time - start_time}"
-                )
-                # if self.debug:
-                #     self.screenshot(f'not in team while switching chars_{current_char}_to_{switch_to} {now - start}')
-                # confirm = self.wait_feature('revive_confirm_hcenter_vcenter', threshold=0.8, time_out=2)
-                # if confirm:
-                #     self.log_info(f'char dead')
-                #     if not self.revive_action():
-                #         self.raise_not_in_combat(f'char dead', exception_type=CharDeadException)
-                if current_time - start_time > self.switch_char_time_out:
-                    self.raise_not_in_combat(
-                        f"switch too long failed chars_{current_char}_to_{switch_to}, {current_time - start_time}"
-                    )
-                self.next_frame()
-                continue
-
-            if current_time - last_click_time > 0.1:
-                self.send_key(switch_to.index + 1)
-                self.sleep(0.001)
-                last_click_time = current_time
-
-            if current_time - start_time > 10:
-                if self.debug:
-                    self.screenshot(f"switch_not_detected_{current_char}_to_{switch_to}")
-                self.raise_not_in_combat("failed switch chars")
-
-            self.next_frame()
-
-        if has_intro:
-            self.record_element_ring_reaction(current_char, switch_to)
-
-        if post_action:
-            logger.debug(f"post_action {post_action}")
-            post_action(switch_to, has_intro)
-
-        logger.info(f"switch_next_char end {(current_char.last_switch_time - start_time):.3f}s")
 
     def get_ultimate_key(self):
         """获取终结技技能的按键。
@@ -573,6 +504,139 @@ class BaseCombatTask(CombatCheck):
         for char in self.chars:
             if isinstance(char, char_cls):
                 return char
+
+    def get_char_by_builtin_key(self, builtin_key: str):
+        for char in self.chars:
+            if char and getattr(char, "builtin_key", None) == builtin_key:
+                return char
+        return None
+
+    def _perform_switch(
+        self,
+        current_char: "BaseChar",
+        switch_to: "BaseChar",
+        has_intro: bool,
+        post_action=None,
+        allow_dynamic_intro_update: bool = True,
+        free_intro: bool = False,
+    ) -> bool:
+        if switch_to is None or switch_to == current_char:
+            logger.warning(f"{current_char} failed to find a valid switch target")
+            return False
+
+        switch_to.has_intro = has_intro
+        logger.info(
+            f"switch_next_char {current_char} -> {switch_to} has_intro {switch_to.has_intro}"
+        )
+
+        last_click_time = 0.0
+        last_decide_time = 0.0
+        start_time = time.time()
+        self.has_char_slot_changed(switch_to.index, reset_char_slot=True)
+
+        while True:
+            self.check_combat()
+            current_time = time.time()
+
+            is_char_switched = self.has_char_slot_changed(switch_to.index)
+
+            if not is_char_switched:
+                self.click(interval=0.2)
+            else:
+                self.in_ultimate = False
+                current_char.switch_out()
+                switch_to.is_current_char = True
+                if has_intro:
+                    current_char.last_outro_time = time.time()
+                break
+
+            if (
+                allow_dynamic_intro_update
+                and not is_char_switched
+                and not has_intro
+                and current_time - last_decide_time > 0.12
+            ):
+                last_decide_time = current_time
+                new_switch_to, new_has_intro = self._decide_switch_to(
+                    current_char, free_intro, require_intro=True
+                )
+                if new_has_intro and new_switch_to != current_char:
+                    switch_to = new_switch_to
+                    has_intro = new_has_intro
+                    switch_to.has_intro = True
+                    logger.info(
+                        f"switch_next_char updated target to {switch_to} has_intro {switch_to.has_intro}"
+                    )
+
+            if not self.is_in_team():
+                logger.info(
+                    f"not in world while switching chars_{current_char}_to_{switch_to} {current_time - start_time}"
+                )
+                if current_time - start_time > self.switch_char_time_out:
+                    self.raise_not_in_combat(
+                        f"switch too long failed chars_{current_char}_to_{switch_to}, {current_time - start_time}"
+                    )
+                self.next_frame()
+                continue
+
+            if current_time - last_click_time > 0.1:
+                self.send_key(switch_to.index + 1)
+                self.sleep(0.001)
+                last_click_time = current_time
+
+            if current_time - start_time > 10:
+                if self.debug:
+                    self.screenshot(f"switch_not_detected_{current_char}_to_{switch_to}")
+                self.raise_not_in_combat("failed switch chars")
+
+            self.next_frame()
+
+        if has_intro:
+            self.record_element_ring_reaction(current_char, switch_to)
+
+        if post_action:
+            logger.debug(f"post_action {post_action}")
+            post_action(switch_to, has_intro)
+
+        logger.info(f"switch_next_char end {(current_char.last_switch_time - start_time):.3f}s")
+        return True
+
+    def switch_to_char(
+        self,
+        current_char: "BaseChar",
+        target_char: "BaseChar",
+        post_action=None,
+        free_intro: bool = False,
+    ) -> bool:
+        if self.team_size <= 1:
+            self.click(interval=0.1)
+            return False
+
+        current_char.wait_switch_cd()
+        has_intro = free_intro or current_char.is_cycle_full()
+        return self._perform_switch(
+            current_char,
+            target_char,
+            has_intro,
+            post_action=post_action,
+            allow_dynamic_intro_update=False,
+            free_intro=free_intro,
+        )
+
+    def switch_to_builtin_char(
+        self,
+        current_char: "BaseChar",
+        builtin_key: str,
+        post_action=None,
+        free_intro: bool = False,
+    ) -> bool:
+        target_char = self.get_char_by_builtin_key(builtin_key)
+        if target_char is None:
+            logger.warning(f"switch_to_builtin_char target not found: {builtin_key}")
+            return False
+        return self.switch_to_char(
+            current_char, target_char, post_action=post_action, free_intro=free_intro
+        )
 
     def _do_load_char(self, index: int, count: int, fixed_slots) -> "BaseChar":
         fixed_slot = safe_get(fixed_slots, index)

--- a/tests/TestNanallyTeamChar.py
+++ b/tests/TestNanallyTeamChar.py
@@ -1,0 +1,34 @@
+import unittest
+
+from ok.test.TaskTestCase import TaskTestCase
+
+from src.char.CharFactory import get_char_by_name
+from src.char.NanallyTeamJiuyuan import NanallyTeamJiuyuan
+from src.char.NanallyTeamNanally import NanallyTeamNanally
+from src.char.NanallyTeamSakiri import NanallyTeamSakiri
+from src.char.NanallyTeamZero import NanallyTeamZero
+from src.char.custom.BuiltinComboRegistry import BuiltinComboRegistry
+from src.config import config
+from src.tasks.trigger.AutoCombatTask import AutoCombatTask
+
+
+class TestNanallyTeamChar(TaskTestCase):
+    task_class = AutoCombatTask
+    config = config
+
+    def test_builtin_team_chars_registered(self):
+        cases = [
+            ("char_nanally_team_nanally", NanallyTeamNanally),
+            ("char_nanally_team_zero", NanallyTeamZero),
+            ("char_nanally_team_jiuyuan", NanallyTeamJiuyuan),
+            ("char_nanally_team_sakiri", NanallyTeamSakiri),
+        ]
+
+        for builtin_key, char_cls in cases:
+            combo_ref = BuiltinComboRegistry.make_ref(builtin_key)
+            char = get_char_by_name(self.task, 0, "test_char", combo_ref=combo_ref)
+            self.assertIsInstance(char, char_cls)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 改动说明

本次改动分为两部分：

1. 通用战斗能力补充
2. 娜娜莉队自动战斗脚本实现

## 具体内容

### 1. 通用战斗能力补充

- 为战斗流程补充定向切人能力，支持角色在出招后按指定目标切换，而不是仅依赖原有的自动择优切人逻辑
- 提取并复用底层切人流程，减少后续固定轮转队伍脚本的重复实现
- 为角色基类补充长按技能能力
- 为角色基类补充“持续普攻直到条件成立”的通用辅助方法，便于实现按技能状态、圆环能量等条件驱动的战斗逻辑

### 2. 娜娜莉队自动战斗脚本

新增以下内置角色脚本：

- 娜娜莉队-娜娜莉
- 娜娜莉队-零
- 娜娜莉队-九原
- 娜娜莉队-早雾

并完成内置注册，使其可以通过固定队伍 / 内置出招表方式直接使用。

## 战斗逻辑

当前实现的轮转逻辑如下：

- 早雾首发：
  - 有大招时优先开大
  - 协奏切入时先等待 2 秒
  - 长按技能 2 秒
  - 切九原

- 九原：
  - 有大招时优先开大
  - 释放技能
  - 长按普攻 2.5 秒
  - 切零

- 零：
  - 有大招时优先开大
  - 释放技能
  - 切娜娜莉

- 娜娜莉：
  - 如果技能未就绪，则先普攻直到技能可用
  - 释放技能后进入持续输出阶段
  - 持续输出期间如果大招转好，则立即开大
  - 技能开启后至少持续 10 秒
  - 满足“技能开启至少 10 秒”且“圆环能量已满”后切早雾
  - 保留超时兜底，避免特殊情况下长时间卡住

## 测试

- 新增内置角色注册测试，确认娜娜莉队角色脚本可以被正确实例化
- 本地已通过相关语法检查与新增测试


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增四个角色实现及其自动战斗序列
  * 添加角色队列切换机制，支持预定义角色自动切换
  * 增强战斗辅助方法，包括技能保持与持续攻击功能

* **测试**
  * 新增角色注册验证测试

<!-- end of auto-generated comment: release notes by coderabbit.ai -->