### PR TITLE
fix(FishingTask): lower success text threshold to 20%

### DIFF
--- a/src/tasks/FishingTask.py
+++ b/src/tasks/FishingTask.py
@@ -451,7 +451,7 @@ class FishingTask(BaseNTETask):
         检测成功文本是否存在
         """
         box = self.box_of_screen(*self.SUCCESS_TEXT_BOX, name="success_text")
-        return self.calculate_color_percentage(text_white_color, box) > 0.3
+        return self.calculate_color_percentage(text_white_color, box) > 0.2
 
     def is_fish_bait_exist(self):
         """


### PR DESCRIPTION
The script fails on the success overlay because the white pixel percentage is under 30%.

Color analysis shows it is currently at 29.19% on english text:
```
1. 32.98% | RGB: ( 46,  92, 118)
2. 29.19% | RGB: (225, 225, 225)
3. 26.21% | RGB: (  1,   2,   2)
4.  6.20% | RGB: (151, 151, 151)
5.  5.41% | RGB: ( 34,  45,  50)
```

<img width="266" height="58" alt="image" src="https://github.com/user-attachments/assets/dd03c5e1-8a4d-451f-b81c-4f96bd2a3389" />

Here is a distribution of the colors. Maybe it can be improved by removing the black text outline from the pool so that it would be definitely over 30%, or detect 20% white and 20% black to make it more fail-proof:
<img width="500" height="100" alt="color_summary_cropped" src="https://github.com/user-attachments/assets/576823af-6d2c-4d99-bdd9-8ffb20ee4227" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* 调整了钓鱼任务成功检测的参数。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->