### PR TITLE
支持自动启动游戏

### DIFF
--- a/launcher/README.md
+++ b/launcher/README.md
@@ -1,0 +1,6 @@
+# ok-nte-launcher
+用于打开异环启动器，并且启动异环
+
+运行脚本`python launcher.py -t 1`
+
+首次运行时，需要先打开异环启动器

--- a/launcher/launcher.py
+++ b/launcher/launcher.py
@@ -1,0 +1,49 @@
+from ok import OK
+
+global_config = {
+    'custom_tasks':True, # enable creating and editing custom tasks
+    'debug': False,  # Optional, default: False
+    'use_gui': True, # 目前只支持True
+    'config_folder': 'configs', #最好不要修改
+    'gui_icon': 'icons/icon.png', #窗口图标, 最好不需要修改文件名
+    'ocr': { #可选, 使用的OCR库
+        'lib': 'onnxocr',
+        'auto_simplify': True, #自动繁体转简体, 需要ppocrv5等可以识别繁体的库
+        'params': {
+            'use_openvino': True,
+        }
+    },
+    'windows': {  # Windows游戏请填写此设置
+        'exe': ['NTEGame.exe'],
+        'interaction': ['Pynput', 'PostMessage', 'Genshin', 'PyDirect','ForegroundPostMessage'], # Genshin:某些操作可以后台, 部分游戏支持 PostMessage:可后台点击, 极少游戏支持 ForegroundPostMessage:前台使用PostMessage Pynput/PyDirect:仅支持前台使用
+        'capture_method': ['WGC', 'BitBlt_RenderFull', 'BitBlt'],  # Windows版本支持的话, 优先使用WGC, 否则使用BitBlt_Full. 支持的capture有 BitBlt, WGC, BitBlt_RenderFull, DXGI
+        'check_hdr': False, #当用户开启AutoHDR时候提示用户, 但不禁止使用
+        'force_no_hdr': False, #True=当用户开启AutoHDR时候禁止使用
+        'require_bg': True # 要求使用后台截图
+    },
+    'window_size': { #ok-script窗口大小
+        'width': 1200,
+        'height': 800,
+        'min_width': 600,
+        'min_height': 450,
+    },
+    'supported_resolution': {
+        'ratio': '16:9', #支持的游戏分辨率
+        'min_size': (1280, 720), #支持的最低游戏分辨率
+        'resize_to': [(2560, 1440), (1920, 1080), (1600, 900), (1280, 720)], #可选, 如果非16:9自动缩放为 resize_to
+    },
+    'screenshots_folder': "screenshots", #截图存放目录, 每次重新启动会清空目录
+    'gui_title': 'ok-nte-launcher',  #窗口名
+    'my_app': ['src.globals', 'Globals'], #可选. 全局单例对象, 可以存放加载的模型, 使用og.my_app调用
+    'onetime_tasks': [  # 用户点击触发的任务
+        ["src.StartTask", "StartTask"],
+    ],
+}
+
+def launch():
+    config = global_config
+    ok = OK(config)
+    ok.start()
+
+if __name__ == '__main__':
+    launch()

--- a/launcher/launcher.py
+++ b/launcher/launcher.py
@@ -24,7 +24,7 @@ global_config = {
         }
     },
     'windows': {
-        'exe': ['NTEGame.exe'],
+        'exe': ['NTEGame.exe'], # 启动器进程名NTEGame.exe
         'interaction': ['Pynput', 'PostMessage', 'Genshin', 'PyDirect','ForegroundPostMessage'],
         'capture_method': ['WGC', 'BitBlt_RenderFull', 'BitBlt'],
         'check_hdr': False,

--- a/launcher/launcher.py
+++ b/launcher/launcher.py
@@ -1,53 +1,57 @@
 import os
 import sys
 
+# select current directory as the working directory
+# ensure import and config can be found correctly
 current_dir = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, current_dir)
 os.chdir(current_dir)
 
 from ok import OK
 
+# See more on https://github.com/ok-oldking/ok-py/blob/master/src/config.py
 global_config = {
-    'custom_tasks':True, # enable creating and editing custom tasks
-    'debug': False,  # Optional, default: False
-    'use_gui': True, # 目前只支持True
-    'config_folder': 'configs', #最好不要修改
-    'gui_icon': 'icons/icon.png', #窗口图标, 最好不需要修改文件名
-    'ocr': { #可选, 使用的OCR库
+    'custom_tasks':True,
+    'debug': False,
+    'use_gui': True,
+    'config_folder': 'configs',
+    'gui_icon': 'icons/icon.png',
+    'ocr': {
         'lib': 'onnxocr',
-        'auto_simplify': True, #自动繁体转简体, 需要ppocrv5等可以识别繁体的库
+        'auto_simplify': True,
         'params': {
             'use_openvino': True,
         }
     },
-    'windows': {  # Windows游戏请填写此设置
+    'windows': {
         'exe': ['NTEGame.exe'],
-        'interaction': ['Pynput', 'PostMessage', 'Genshin', 'PyDirect','ForegroundPostMessage'], # Genshin:某些操作可以后台, 部分游戏支持 PostMessage:可后台点击, 极少游戏支持 ForegroundPostMessage:前台使用PostMessage Pynput/PyDirect:仅支持前台使用
-        'capture_method': ['WGC', 'BitBlt_RenderFull', 'BitBlt'],  # Windows版本支持的话, 优先使用WGC, 否则使用BitBlt_Full. 支持的capture有 BitBlt, WGC, BitBlt_RenderFull, DXGI
-        'check_hdr': False, #当用户开启AutoHDR时候提示用户, 但不禁止使用
-        'force_no_hdr': False, #True=当用户开启AutoHDR时候禁止使用
-        'require_bg': True # 要求使用后台截图
+        'interaction': ['Pynput', 'PostMessage', 'Genshin', 'PyDirect','ForegroundPostMessage'],
+        'capture_method': ['WGC', 'BitBlt_RenderFull', 'BitBlt'],
+        'check_hdr': False,
+        'force_no_hdr': False,
+        'require_bg': True
     },
-    'window_size': { #ok-script窗口大小
+    'window_size': {
         'width': 1200,
         'height': 800,
         'min_width': 600,
         'min_height': 450,
     },
     'supported_resolution': {
-        'ratio': '16:9', #支持的游戏分辨率
-        'min_size': (1280, 720), #支持的最低游戏分辨率
-        'resize_to': [(2560, 1440), (1920, 1080), (1600, 900), (1280, 720)], #可选, 如果非16:9自动缩放为 resize_to
+        'ratio': '16:9',
+        'min_size': (1280, 720),
+        'resize_to': [(2560, 1440), (1920, 1080), (1600, 900), (1280, 720)],
     },
-    'screenshots_folder': "screenshots", #截图存放目录, 每次重新启动会清空目录
-    'gui_title': 'ok-nte-launcher',  #窗口名
-    'my_app': ['src.globals', 'Globals'], #可选. 全局单例对象, 可以存放加载的模型, 使用og.my_app调用
-    'onetime_tasks': [  # 用户点击触发的任务
+    'screenshots_folder': "screenshots",
+    'gui_title': 'ok-nte-launcher',
+    'my_app': ['src.globals', 'Globals'],
+    'onetime_tasks': [
         ["src.StartTask", "StartTask"],
     ],
 }
 
 def launch():
+    '''启动器启动游戏'''
     config = global_config
     ok = OK(config)
     ok.start()

--- a/launcher/launcher.py
+++ b/launcher/launcher.py
@@ -1,3 +1,10 @@
+import os
+import sys
+
+current_dir = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, current_dir)
+os.chdir(current_dir)
+
 from ok import OK
 
 global_config = {

--- a/launcher/src/StartTask.py
+++ b/launcher/src/StartTask.py
@@ -10,9 +10,19 @@ class StartTask(BaseTask):
         self.description = "通过启动器启动游戏"
         self.icon = FluentIcon.SYNC
 
-    def run(self):
-        self.log_info('启动器任务开始运行!', notify=True)
-        if self.wait_click_ocr(match=re.compile("开始")):
-            self.log_info('启动器任务运行完成!', notify=True)
+    def _start(self, time_out=10):
+        '''点击开始'''
+        if self.wait_click_ocr(match=re.compile("开始"), time_out=time_out):
+            self.log_info('启动器点击开始', notify=True)
         else:
-            self.log_error('启动器任务运行失败!', notify=True)
+            self.log_error('启动器点击开始失败', notify=True)
+
+    def run(self):
+        '''检测更新 -> 点击开始'''
+        self.log_info('启动器任务开始运行', notify=True)
+        if self.wait_click_ocr(match=re.compile("更新"), after_sleep=60):
+            self.log_info('启动器更新', notify=True)
+            self._start()
+        else:
+            self.log_info('未找到更新', notify=True)
+            self._start()

--- a/launcher/src/StartTask.py
+++ b/launcher/src/StartTask.py
@@ -1,0 +1,18 @@
+from ok import BaseTask
+import re
+from qfluentwidgets import FluentIcon
+
+class StartTask(BaseTask):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.name = "启动器任务"
+        self.description = "通过启动器启动游戏"
+        self.icon = FluentIcon.SYNC
+
+    def run(self):
+        self.log_info('启动器任务开始运行!', notify=True)
+        if self.wait_click_ocr(match=re.compile("开始")):
+            self.log_info('启动器任务运行完成!', notify=True)
+        else:
+            self.log_error('启动器任务运行失败!', notify=True)

--- a/launcher/src/globals.py
+++ b/launcher/src/globals.py
@@ -1,0 +1,12 @@
+from PySide6.QtCore import QObject
+
+from ok import Logger
+
+logger = Logger.get_logger(__name__)
+
+
+class Globals(QObject):
+
+    def __init__(self, exit_event):
+        super().__init__()
+

--- a/main.py
+++ b/main.py
@@ -1,8 +1,41 @@
 import ok
+import subprocess
+import psutil
+import time
 
 from src.config import config
 
+def is_HTGame_running():
+    '''判断HTGame是否正在运行'''
+    process_name = "HTGame.exe"
+    process_name = process_name.lower()
+    for proc in psutil.process_iter(['name']):
+        try:
+            proc_name = proc.info['name'].lower()
+            if process_name in proc_name:
+                return True
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            continue
+    return False
+
+def wait_for_HTGame():
+    '''等待HTGame启动'''
+    if not is_HTGame_running():
+        print("游戏未启动，通过启动器启动")
+        # 启动器启动游戏
+        subprocess.Popen(["python", "launcher/launcher.py", "-t 1"])
+        start_time = time.time()
+        while not is_HTGame_running() and time.time() - start_time < 60:
+            print("等待游戏启动...")
+            time.sleep(1)
+        if not is_HTGame_running():
+            print("游戏启动超时")
+            exit(1)
+
 if __name__ == "__main__":
+    # 如果游戏未启动，通过启动器启动并等待启动
+    wait_for_HTGame()
+
     config = config
     ok = ok.OK(config)
     ok.start()

--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ import time
 
 from src.config import config
 
-def is_HTGame_running():
+def is_htgame_running():
     '''判断HTGame是否正在运行'''
     process_name = "HTGame.exe"
     process_name = process_name.lower()
@@ -18,23 +18,23 @@ def is_HTGame_running():
             continue
     return False
 
-def wait_for_HTGame():
+def wait_for_htgame():
     '''等待HTGame启动'''
-    if not is_HTGame_running():
+    if not is_htgame_running():
         print("游戏未启动，通过启动器启动")
         # 启动器启动游戏
         subprocess.Popen(["python", "launcher/launcher.py", "-t 1"])
         start_time = time.time()
-        while not is_HTGame_running() and time.time() - start_time < 60:
+        while not is_htgame_running() and time.time() - start_time < 60:
             print("等待游戏启动...")
             time.sleep(1)
-        if not is_HTGame_running():
+        if not is_htgame_running():
             print("游戏启动超时")
             exit(1)
 
 if __name__ == "__main__":
     # 如果游戏未启动，通过启动器启动并等待启动
-    wait_for_HTGame()
+    wait_for_htgame()
 
     config = config
     ok = ok.OK(config)


### PR DESCRIPTION
https://github.com/BnanZ0/ok-nte/discussions/66
## 分析问题
异环必须通过启动器启动，并且启动期间启动器必须全程存活

## 解决方案
* 添加脚本(ok-nte-launcher)，用于 启动异环启动器 -> 点击更新 -> 点击开始 -> 异环启动
* 在ok-nte运行前起子进程ok-nte-launcher用于自动启动游戏

## 测试方案
* 首次运行前需要打开启动器(NTEGame.exe) 随后运行`python main.py`即可
* 单独测试ok-nte-launcher脚本 `python launcher/launcher.py -t 1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增启动器脚本，支持以配置方式启动并运行游戏启动流程
  * 新增启动任务，能识别界面提示（如更新/开始）并自动点击以启动游戏，带日志与通知反馈

* **文档**
  * 添加项目使用说明（启动器 README），包含运行示例与首次启动注意事项

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BnanZ0/ok-nte/pull/67)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->