### PR TITLE
fix(daily): 修复手机菜单状态下邮件入口恢复

### DIFF
--- a/src/tasks/DailyTask.py
+++ b/src/tasks/DailyTask.py
@@ -1,9 +1,11 @@
 from datetime import datetime
 from typing import Callable, List, Tuple
 
+import cv2
+import numpy as np
 from qfluentwidgets import FluentIcon
 
-from ok import CannotFindException, TaskDisabledException, find_color_rectangles
+from ok import TaskDisabledException, find_color_rectangles
 from src import text_white_color
 from src.Labels import Labels
 from src.tasks.AnomalyTask import AnomalyTask
@@ -23,6 +25,12 @@ class DailyTask(NTEOneTimeTask, BaseNTETask):
 
     CONF_AUTO_CYCLE_SUB_TASK = "自动循环项目"
     DAILY_STAMINA_TARGET = 180
+    MAIL_BUTTON_POSITION = (0.8707, 0.8736)
+    MAIL_PANEL_WAIT_TIMEOUT = 4.5
+    MAIL_PHONE_MENU_MAIL_ICON_REGION = (0.50, 0.83, 0.72, 0.97)
+    MAIL_PHONE_MENU_GLOBAL_MAIL_ICON_REGION = (0.82, 0.78, 0.92, 0.91)
+    MAIL_PHONE_MENU_MAIL_ICON_THRESHOLD = 135
+    MAIL_PHONE_MENU_MAIL_ICON_MIN_AREA = 160
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -149,22 +157,117 @@ class DailyTask(NTEOneTimeTask, BaseNTETask):
             bool: True 表示成功，False 表示失败
         """
         self.log_info("正在打开邮件面板")
-        self.openESCpanel()
-        self.operate_click(0.8707, 0.8736)
-        self.sleep(1)
-        result = self.wait_panel(Labels.mail_panel)
+        panel = self.openESCpanel()
+        phone_click = self._click_mail_button_from_phone_menu(panel)
+        if phone_click is False:
+            self.info_set("邮件入口恢复失败", "phone_menu_mail_icon_not_found")
+            self.log_error("检测到手机菜单但无法定位邮件入口", notify=True)
+            return False
+        if phone_click is None:
+            self.operate_click(*self.MAIL_BUTTON_POSITION)
+            self.sleep(1)
+        result = self._wait_mail_panel()
         if not result:
+            self.info_set("邮件入口恢复失败", "mail_panel_not_found")
             self.log_error("无法找到邮件面板", notify=True)
-            raise CannotFindException("can't find mail panel")
+            return False
         return result
 
     def claim_mail(self):
         """领取邮件"""
         self.log_info("正在领取邮件奖励")
-        self._open_mail_panel()
+        if not self._open_mail_panel():
+            return False
         self.operate_click(0.1289, 0.9299)
         self.sleep(1)
         return True
+
+    def _wait_mail_panel(self):
+        result = self.wait_panel(Labels.mail_panel, time_out=self.MAIL_PANEL_WAIT_TIMEOUT)
+        if not result:
+            return None
+        name = str(getattr(result, "name", "") or "")
+        if name and name not in {Labels.mail_panel, Labels.mail_panel.value}:
+            self.log_info(f"邮件面板识别结果不是邮件面板: {name}")
+            return None
+        return result
+
+    def _click_mail_button_from_phone_menu(self, panel):
+        target = self._find_mail_icon_from_phone_menu(panel)
+        if target is None and self._is_mail_phone_menu_box(panel):
+            return False
+        if target is None:
+            return None
+        self.log_info("识别到手机菜单邮件入口，点击信封图标中心")
+        self.operate_click(int(target[0]), int(target[1]), down_time=0.08)
+        self.sleep(1)
+        return True
+
+    @staticmethod
+    def _is_mail_phone_menu_box(panel):
+        return getattr(panel, "name", "") in {"mail_phone_menu", "esc_phone_menu"}
+
+    def _find_mail_icon_from_phone_menu(self, panel):
+        frame = self._mail_current_frame()
+        shape = getattr(frame, "shape", None)
+        if shape is None or len(shape) < 2:
+            return None
+        height, width = shape[:2]
+        if self._is_mail_phone_menu_box(panel):
+            px, py = int(getattr(panel, "x", 0) or 0), int(getattr(panel, "y", 0) or 0)
+            pw, ph = int(getattr(panel, "width", 0) or 0), int(getattr(panel, "height", 0) or 0)
+            if pw <= 0 or ph <= 0:
+                return None
+            x1, y1, x2, y2 = self._ratio_region_bounds(pw, ph, self.MAIL_PHONE_MENU_MAIL_ICON_REGION)
+            x1, x2 = max(0, px + x1), min(width, px + x2)
+            y1, y2 = max(0, py + y1), min(height, py + y2)
+        else:
+            x1, y1, x2, y2 = self._ratio_region_bounds(
+                width,
+                height,
+                self.MAIL_PHONE_MENU_GLOBAL_MAIL_ICON_REGION,
+            )
+        if x2 <= x1 or y2 <= y1:
+            return None
+        crop = frame[y1:y2, x1:x2]
+        if getattr(crop, "size", 0) == 0:
+            return None
+        gray = cv2.cvtColor(crop, cv2.COLOR_BGR2GRAY) if len(crop.shape) == 3 else crop
+        mask = (gray > self.MAIL_PHONE_MENU_MAIL_ICON_THRESHOLD).astype(np.uint8)
+        count, _, stats, _ = cv2.connectedComponentsWithStats(mask, 8)
+        candidates = []
+        for label in range(1, count):
+            area = int(stats[label, cv2.CC_STAT_AREA])
+            box_width = int(stats[label, cv2.CC_STAT_WIDTH])
+            box_height = int(stats[label, cv2.CC_STAT_HEIGHT])
+            if area < self.MAIL_PHONE_MENU_MAIL_ICON_MIN_AREA or box_width < 20 or box_height < 14:
+                continue
+            x = int(stats[label, cv2.CC_STAT_LEFT])
+            y = int(stats[label, cv2.CC_STAT_TOP])
+            candidates.append((area, x1 + x + box_width / 2, y1 + y + box_height / 2))
+        if not candidates:
+            return None
+        _, center_x, center_y = max(candidates, key=lambda item: item[0])
+        return center_x, center_y
+
+    def _mail_current_frame(self):
+        next_frame = getattr(self, "next_frame", None)
+        if callable(next_frame):
+            try:
+                frame = next_frame()
+                if frame is not None:
+                    return frame
+            except Exception:
+                pass
+        try:
+            return self.frame
+        except Exception:
+            return None
+
+    @staticmethod
+    def _ratio_region_bounds(width, height, region):
+        left, top, right, bottom = region
+        return int(width * left), int(height * top), int(width * right), int(height * bottom)
 
     def complete_daily_activities(self):
         """执行操作完成每日活跃度""" 

--- a/tests/TestDailyTaskMail.py
+++ b/tests/TestDailyTaskMail.py
@@ -1,0 +1,110 @@
+import unittest
+from unittest.mock import Mock
+
+import numpy as np
+
+from ok import Box
+from src.Labels import Labels
+from src.tasks.DailyTask import DailyTask
+
+
+class TestDailyTaskMail(unittest.TestCase):
+    def make_task(self):
+        task = object.__new__(DailyTask)
+        task.log_info = Mock()
+        task.log_error = Mock()
+        task.info_set = Mock()
+        task.sleep = Mock()
+        task.operate_click = Mock()
+        return task
+
+    def test_wait_mail_panel_rejects_generic_esc_panel(self):
+        task = self.make_task()
+        esc_panel = Mock(name="esc_option")
+        esc_panel.name = Labels.esc_option.value
+        task.wait_panel = Mock(return_value=esc_panel)
+
+        result = DailyTask._wait_mail_panel(task)
+
+        self.assertIsNone(result)
+        task.wait_panel.assert_called_once_with(
+            Labels.mail_panel,
+            time_out=DailyTask.MAIL_PANEL_WAIT_TIMEOUT,
+        )
+
+    def test_click_mail_button_from_phone_menu_uses_detected_icon_center(self):
+        task = self.make_task()
+        frame = np.zeros((1080, 1920, 3), dtype=np.uint8)
+        frame[900:940, 1650:1690] = 255
+        panel = Box(1344, 108, 537, 885, name="mail_phone_menu")
+        task.next_frame = Mock(return_value=frame)
+
+        result = DailyTask._click_mail_button_from_phone_menu(task, panel)
+
+        self.assertTrue(result)
+        task.operate_click.assert_called_once_with(1670, 920, down_time=0.08)
+        task.sleep.assert_called_once_with(1)
+
+    def test_open_mail_panel_uses_phone_menu_and_verifies_mail_panel(self):
+        task = self.make_task()
+        frame = np.zeros((1080, 1920, 3), dtype=np.uint8)
+        frame[900:940, 1650:1690] = 255
+        panel = Box(1344, 108, 537, 885, name="mail_phone_menu")
+        mail_panel = Mock(name="mail_panel")
+        mail_panel.name = Labels.mail_panel.value
+        task.openESCpanel = Mock(return_value=panel)
+        task.next_frame = Mock(return_value=frame)
+        task.wait_panel = Mock(return_value=mail_panel)
+
+        result = DailyTask._open_mail_panel(task)
+
+        self.assertIs(result, mail_panel)
+        task.operate_click.assert_called_once_with(1670, 920, down_time=0.08)
+        task.wait_panel.assert_called_once_with(
+            Labels.mail_panel,
+            time_out=DailyTask.MAIL_PANEL_WAIT_TIMEOUT,
+        )
+
+    def test_open_mail_panel_recovers_from_generic_esc_panel_when_mail_icon_visible(self):
+        task = self.make_task()
+        frame = np.zeros((1080, 1920, 3), dtype=np.uint8)
+        frame[900:940, 1650:1690] = 255
+        esc_panel = Mock(name="esc_option")
+        esc_panel.name = Labels.esc_option.value
+        mail_panel = Mock(name="mail_panel")
+        mail_panel.name = Labels.mail_panel.value
+        task.openESCpanel = Mock(return_value=esc_panel)
+        task.next_frame = Mock(return_value=frame)
+        task.wait_panel = Mock(return_value=mail_panel)
+
+        result = DailyTask._open_mail_panel(task)
+
+        self.assertIs(result, mail_panel)
+        task.operate_click.assert_called_once_with(1670, 920, down_time=0.08)
+
+    def test_open_mail_panel_reports_blocker_when_phone_menu_icon_missing(self):
+        task = self.make_task()
+        frame = np.zeros((1080, 1920, 3), dtype=np.uint8)
+        panel = Box(1344, 108, 537, 885, name="mail_phone_menu")
+        task.openESCpanel = Mock(return_value=panel)
+        task.next_frame = Mock(return_value=frame)
+        task.wait_panel = Mock()
+
+        result = DailyTask._open_mail_panel(task)
+
+        self.assertFalse(result)
+        task.operate_click.assert_not_called()
+        task.wait_panel.assert_not_called()
+        task.info_set.assert_called_once_with(
+            "邮件入口恢复失败",
+            "phone_menu_mail_icon_not_found",
+        )
+
+    def test_claim_mail_returns_false_when_open_mail_panel_fails(self):
+        task = self.make_task()
+        task._open_mail_panel = Mock(return_value=False)
+
+        result = DailyTask.claim_mail(task)
+
+        self.assertFalse(result)
+        task.operate_click.assert_not_called()

--- a/tests/TestDailyTaskMail.py
+++ b/tests/TestDailyTaskMail.py
@@ -81,6 +81,33 @@ class TestDailyTaskMail(unittest.TestCase):
 
         self.assertIs(result, mail_panel)
         task.operate_click.assert_called_once_with(1670, 920, down_time=0.08)
+        self.assertNotEqual(
+            task.operate_click.call_args.args,
+            DailyTask.MAIL_BUTTON_POSITION,
+        )
+        task.wait_panel.assert_called_once_with(
+            Labels.mail_panel,
+            time_out=DailyTask.MAIL_PANEL_WAIT_TIMEOUT,
+        )
+
+    def test_open_mail_panel_requires_post_verification_after_phone_menu_click(self):
+        task = self.make_task()
+        frame = np.zeros((1080, 1920, 3), dtype=np.uint8)
+        frame[900:940, 1650:1690] = 255
+        esc_panel = Mock(name="esc_option")
+        esc_panel.name = Labels.esc_option.value
+        task.openESCpanel = Mock(return_value=esc_panel)
+        task.next_frame = Mock(return_value=frame)
+        task.wait_panel = Mock(return_value=None)
+
+        result = DailyTask._open_mail_panel(task)
+
+        self.assertFalse(result)
+        task.operate_click.assert_called_once_with(1670, 920, down_time=0.08)
+        task.info_set.assert_called_once_with(
+            "邮件入口恢复失败",
+            "mail_panel_not_found",
+        )
 
     def test_open_mail_panel_reports_blocker_when_phone_menu_icon_missing(self):
         task = self.make_task()


### PR DESCRIPTION
## 说明

这个 PR 只修复 DailyTask 在 1080p 手机菜单/ESC 菜单状态下进入邮件入口可能失败的问题。

当当前画面已经显示手机菜单里的邮件图标时，优先从当前截图解析邮件图标位置并点击 bbox 中心；只有没有识别到手机菜单邮件入口时，才保留原有的固定比例入口作为兼容回退。

同时，打开邮件后会继续验证 `mail_panel` 是否真正出现；如果仍然没有进入邮件面板，会返回失败而不是把流程当成成功。

## 改动

- 增加手机菜单邮件图标的当前画面解析路径。
- 避免在已识别到手机菜单邮件入口时走旧的固定 `MAIL_BUTTON_POSITION`。
- 打开邮件入口后要求 `mail_panel` 后验成功。
- 增加聚焦单测覆盖 generic ESC panel、图标中心点击、固定坐标未使用、后验失败返回失败。

## 验证

本地验证：

- `uv run --no-sync python -m unittest tests.TestDailyTaskMail`
  - 7 tests OK
- `uv run --no-sync --with pytest python -m pytest -q tests/TestDailyTaskMail.py -o python_files=Test*.py`
  - 7 passed
- `uv run --no-sync python -m compileall src tests scripts`
  - passed
- `git diff --check upstream/main..HEAD`
  - passed

1080p 实机 targeted 验证：

- capture: `1920x1080`
- `phone_menu_detected=true`
- `mail_icon_bbox=[1648, 934, 42, 26]`
- `target_point=[1669, 947]`
- `used_fixed_mail_button_position=false`
- `mutation_verified=true`
- `mail_panel_opened=true`
- `mail_claim_clicked=false`

没有运行 Gift、Coffee、daily-full，也没有提交运行产物。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进邮件声称流程的稳健性，增加了电话菜单恢复机制和更强的邮件面板检测能力。

* **Tests**
  * 新增邮件面板行为测试套件，覆盖多个验证场景。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BnanZ0/ok-nte/pull/77)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->