### PR TITLE
fix(task): 避免 F1 非日常页面误判为活跃面板

### DIFF
--- a/src/tasks/DailyTask.py
+++ b/src/tasks/DailyTask.py
@@ -8,6 +8,7 @@ from src import text_white_color
 from src.Labels import Labels
 from src.tasks.AnomalyTask import AnomalyTask
 from src.tasks.BaseNTETask import BaseNTETask
+from src.tasks.F1PanelDetector import F1PanelDetector
 from src.tasks.NTEOneTimeTask import NTEOneTimeTask
 from src.utils import image_utils as iu
 
@@ -210,7 +211,7 @@ class DailyTask(NTEOneTimeTask, BaseNTETask):
             self.openF1panel()
             self.operate_click(0.0551, 0.3833)
             self.sleep(0.5)
-            return self.wait_panel(Labels.f1_activity_panel)
+            return F1PanelDetector(self).wait_daily_activity_panel()
 
         self.log_info("正在领取活跃度奖励")
         result = self.retry_on_action(action, self.ensure_main)

--- a/src/tasks/F1PanelDetector.py
+++ b/src/tasks/F1PanelDetector.py
@@ -1,0 +1,243 @@
+from dataclasses import dataclass
+
+from ok import Box
+
+from src.Labels import Labels
+
+
+LAYOUT_PROFILE_NATIVE_16_9 = "native_16_9"
+LAYOUT_PROFILE_NATIVE_UNKNOWN = "native_unknown"
+
+
+@dataclass
+class DailyPanelOpenResult:
+    f1_panel_opened: bool
+    daily_tab_clicked: bool
+    daily_activity_panel_detected: bool
+    layout_profile: str
+    reason: str = ""
+
+    def to_dict(self):
+        return {
+            "f1_panel_opened": self.f1_panel_opened,
+            "daily_tab_clicked": self.daily_tab_clicked,
+            "daily_activity_panel_detected": self.daily_activity_panel_detected,
+            "layout_profile": self.layout_profile,
+            "reason": self.reason,
+        }
+
+
+class F1PanelDetector:
+    """识别真正的 F1 每日活跃面板，并拒绝 F1 内其他页面误判。"""
+
+    NATIVE_16_9_DAILY_SELECTED_TAB_REGION = (0.035, 0.330, 0.120, 0.430)
+    NATIVE_16_9_DAILY_PROGRESS_REGION = (0.130, 0.270, 0.360, 0.470)
+    NATIVE_16_9_DAILY_CONTENT_REGION = (0.400, 0.130, 0.970, 0.870)
+    NATIVE_16_9_DAILY_PANEL_REGION = (0.030, 0.090, 0.980, 0.930)
+    MIN_DAILY_TAB_WHITE_RATIO = 0.04
+    MIN_DAILY_PROGRESS_CYAN_RATIO = 0.02
+    MIN_DAILY_CONTENT_WHITE_RATIO = 0.02
+
+    def __init__(self, task):
+        self.task = task
+
+    def wait_daily_activity_panel(self, time_out=4.5):
+        waiter = getattr(self.task, "wait_until", None)
+        if not callable(waiter):
+            return self.find_daily_activity_panel()
+        return waiter(
+            self.find_daily_activity_panel,
+            time_out=time_out,
+            settle_time=0.5,
+        )
+
+    def make_open_result(
+        self,
+        f1_panel_opened,
+        daily_tab_clicked,
+        daily_activity_panel_detected=None,
+        reason="",
+    ):
+        if daily_activity_panel_detected is None:
+            daily_activity_panel_detected = bool(self.find_daily_activity_panel())
+        if daily_activity_panel_detected:
+            reason = "每日活跃度面板已识别"
+        elif not reason:
+            reason = "未确认当前页面是每日活跃度面板"
+        return DailyPanelOpenResult(
+            f1_panel_opened=bool(f1_panel_opened),
+            daily_tab_clicked=bool(daily_tab_clicked),
+            daily_activity_panel_detected=bool(daily_activity_panel_detected),
+            layout_profile=self.layout_profile(),
+            reason=reason,
+        )
+
+    def find_daily_activity_panel(self):
+        label_match = self._find_label(Labels.f1_activity_panel)
+        structure = self.probe_daily_activity_structure()
+        if structure.get("matched"):
+            return label_match or self._box_for_region(
+                structure.get("box_name", "native_daily_activity_panel"),
+                structure["panel_region"],
+                confidence=structure.get("confidence", 1.0),
+            )
+        if label_match:
+            self._log_info(
+                "检测到活跃面板模板，但每日活跃页签或内容结构未命中，"
+                "忽略可能的 F1 非日常页面误识别"
+            )
+        return None
+
+    def probe_daily_activity_structure(self):
+        profile = self.layout_profile()
+        if profile == LAYOUT_PROFILE_NATIVE_16_9:
+            return self._probe_daily_structure(
+                selected_tab_region=self.NATIVE_16_9_DAILY_SELECTED_TAB_REGION,
+                progress_region=self.NATIVE_16_9_DAILY_PROGRESS_REGION,
+                content_region=self.NATIVE_16_9_DAILY_CONTENT_REGION,
+                panel_region=self.NATIVE_16_9_DAILY_PANEL_REGION,
+                box_name="native_16_9_daily_activity_panel",
+            )
+        return {
+            "matched": False,
+            "reason": f"unsupported layout profile: {profile}",
+        }
+
+    def layout_profile(self):
+        getter = getattr(self.task, "get_ui_layout_profile", None)
+        if callable(getter):
+            profile = getter()
+            if profile:
+                return profile
+
+        width, height = self._screen_size()
+        if width <= 0 or height <= 0:
+            return LAYOUT_PROFILE_NATIVE_UNKNOWN
+        ratio = width / height
+        if abs(ratio - (16 / 9)) < 0.02:
+            return LAYOUT_PROFILE_NATIVE_16_9
+        return LAYOUT_PROFILE_NATIVE_UNKNOWN
+
+    def _probe_daily_structure(
+        self,
+        *,
+        selected_tab_region,
+        progress_region,
+        content_region,
+        panel_region,
+        box_name,
+    ):
+        frame = self._current_frame()
+        if frame is None:
+            return {
+                "matched": False,
+                "reason": "frame is unavailable",
+            }
+
+        selected_tab_white_ratio = self._color_ratio(
+            frame,
+            selected_tab_region,
+            lambda b, g, r: (b > 190) & (g > 190) & (r > 190),
+        )
+        progress_cyan_ratio = self._color_ratio(
+            frame,
+            progress_region,
+            lambda b, g, r: (b > 120) & (g > 170) & (r < 160),
+        )
+        content_white_ratio = self._color_ratio(
+            frame,
+            content_region,
+            lambda b, g, r: (b > 190) & (g > 190) & (r > 190),
+        )
+        matched = (
+            selected_tab_white_ratio >= self.MIN_DAILY_TAB_WHITE_RATIO
+            and (
+                progress_cyan_ratio >= self.MIN_DAILY_PROGRESS_CYAN_RATIO
+                or content_white_ratio >= self.MIN_DAILY_CONTENT_WHITE_RATIO
+            )
+        )
+        result = {
+            "matched": matched,
+            "selected_tab_white_ratio": selected_tab_white_ratio,
+            "progress_cyan_ratio": progress_cyan_ratio,
+            "content_white_ratio": content_white_ratio,
+            "panel_region": panel_region,
+            "box_name": box_name,
+            "thresholds": {
+                "selected_tab_white_ratio": self.MIN_DAILY_TAB_WHITE_RATIO,
+                "progress_cyan_ratio": self.MIN_DAILY_PROGRESS_CYAN_RATIO,
+                "content_white_ratio": self.MIN_DAILY_CONTENT_WHITE_RATIO,
+            },
+        }
+        if matched:
+            result["confidence"] = min(
+                1.0,
+                selected_tab_white_ratio / self.MIN_DAILY_TAB_WHITE_RATIO,
+            )
+        else:
+            result["reason"] = "daily activity structure not matched"
+        return result
+
+    def _find_label(self, label):
+        finder = getattr(self.task, "find_one", None)
+        if not callable(finder):
+            return None
+        return finder(label)
+
+    def _current_frame(self):
+        try:
+            return getattr(self.task, "frame", None)
+        except Exception:
+            return None
+
+    def _screen_size(self):
+        width = int(getattr(self.task, "width", 0) or 0)
+        height = int(getattr(self.task, "height", 0) or 0)
+        if width > 0 and height > 0:
+            return width, height
+        frame = self._current_frame()
+        shape = getattr(frame, "shape", None)
+        if shape is not None and len(shape) >= 2:
+            return int(shape[1]), int(shape[0])
+        return width, height
+
+    def _box_for_region(self, name, region, confidence=1.0):
+        width, height = self._screen_size()
+        x, y, to_x, to_y = region
+        return Box(
+            int(width * x),
+            int(height * y),
+            int(width * (to_x - x)),
+            int(height * (to_y - y)),
+            name=name,
+            confidence=confidence,
+        )
+
+    @staticmethod
+    def _color_ratio(frame, region, mask_factory):
+        shape = getattr(frame, "shape", None)
+        if shape is None or len(shape) < 2:
+            return 0.0
+
+        height, width = shape[:2]
+        x1, y1, x2, y2 = region
+        left = max(0, min(width, int(width * x1)))
+        top = max(0, min(height, int(height * y1)))
+        right = max(0, min(width, int(width * x2)))
+        bottom = max(0, min(height, int(height * y2)))
+        if right <= left or bottom <= top:
+            return 0.0
+
+        crop = frame[top:bottom, left:right]
+        if crop.size == 0:
+            return 0.0
+
+        b = crop[:, :, 0]
+        g = crop[:, :, 1]
+        r = crop[:, :, 2]
+        return float(mask_factory(b, g, r).mean())
+
+    def _log_info(self, message):
+        logger = getattr(self.task, "log_info", None)
+        if callable(logger):
+            logger(message)

--- a/tests/TestF1PanelDetector.py
+++ b/tests/TestF1PanelDetector.py
@@ -1,0 +1,91 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import numpy as np
+
+from src.Labels import Labels
+from src.tasks.F1PanelDetector import F1PanelDetector
+
+
+class FakeF1PanelTask:
+    def __init__(self, frame, *, label_match=True):
+        self.frame = frame
+        self.height, self.width = frame.shape[:2]
+        self.log_info = Mock()
+        self.panel = SimpleNamespace(name="f1_activity_panel")
+        self.label_match = label_match
+
+    def find_one(self, label):
+        if label == Labels.f1_activity_panel and self.label_match:
+            return self.panel
+        return None
+
+
+def fill_region(frame, region, color):
+    height, width = frame.shape[:2]
+    x1, y1, x2, y2 = region
+    frame[int(height * y1) : int(height * y2), int(width * x1) : int(width * x2)] = color
+
+
+class TestF1PanelDetector(unittest.TestCase):
+    def _frame(self):
+        return np.zeros((1080, 1920, 3), dtype=np.uint8)
+
+    def test_explore_guide_template_match_is_rejected_when_daily_tab_is_not_selected(self):
+        frame = self._frame()
+        fill_region(frame, (0.035, 0.130, 0.120, 0.310), (230, 230, 230))
+        fill_region(frame, F1PanelDetector.NATIVE_16_9_DAILY_PROGRESS_REGION, (180, 210, 80))
+        task = FakeF1PanelTask(frame)
+
+        result = F1PanelDetector(task).find_daily_activity_panel()
+
+        self.assertIsNone(result)
+        task.log_info.assert_called_once()
+
+    def test_daily_selected_tab_region_accepts_activity_panel_template(self):
+        frame = self._frame()
+        fill_region(
+            frame,
+            F1PanelDetector.NATIVE_16_9_DAILY_SELECTED_TAB_REGION,
+            (230, 230, 230),
+        )
+        fill_region(frame, F1PanelDetector.NATIVE_16_9_DAILY_PROGRESS_REGION, (180, 210, 80))
+        task = FakeF1PanelTask(frame)
+
+        result = F1PanelDetector(task).find_daily_activity_panel()
+
+        self.assertIs(result, task.panel)
+        task.log_info.assert_not_called()
+
+    def test_daily_structure_can_detect_panel_without_template_match(self):
+        frame = self._frame()
+        fill_region(
+            frame,
+            F1PanelDetector.NATIVE_16_9_DAILY_SELECTED_TAB_REGION,
+            (230, 230, 230),
+        )
+        fill_region(frame, F1PanelDetector.NATIVE_16_9_DAILY_PROGRESS_REGION, (180, 210, 80))
+        task = FakeF1PanelTask(frame, label_match=False)
+
+        result = F1PanelDetector(task).find_daily_activity_panel()
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result.name, "native_16_9_daily_activity_panel")
+
+    def test_open_result_preserves_explicit_failed_detection_reason(self):
+        result = F1PanelDetector(FakeF1PanelTask(self._frame())).make_open_result(
+            True,
+            True,
+            False,
+            reason="daily_activity_panel_not_detected",
+        )
+
+        self.assertTrue(result.f1_panel_opened)
+        self.assertTrue(result.daily_tab_clicked)
+        self.assertFalse(result.daily_activity_panel_detected)
+        self.assertEqual(result.reason, "daily_activity_panel_not_detected")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 概要

本 PR 增加一个轻量的 F1 面板识别模块，用于确认当前页面确实是“每日活跃”面板，而不是 F1 里的“探索指南”等其他页面。

核心变化：
- 新增 `F1PanelDetector`。
- 每日活跃奖励领取不再只依赖 `f1_activity_panel` 模板命中。
- 模板命中后，还会检查每日活跃页签和内容区域的结构特征。
- “探索指南”等非每日页即使误命中模板，也会被拒绝，不会继续执行后续奖励点击。

## 背景

上游当前逻辑在打开 F1 后点击每日栏目，然后直接等待 `f1_activity_panel` 模板。如果 F1 停留在其他页面，模板误命中可能被当成每日活跃面板，后续点击就会落到错误页面。

这个 PR 把 F1 每日面板判断抽成独立小模块，只解决面板误判问题，不引入 fork 中更大的 Daily 模块化流程。本 PR 只提交适合 upstream 的 16:9 小范围修复；额外本地布局适配保留在 fork，不放入本次上游 PR。

## 实现

- 对 16:9 原生布局检查每日活跃页签区域。
- 只有每日页签区域达到白色选中比例，并且进度或内容区域符合每日活跃页面结构时，才认为面板有效。
- 如果结构命中，即使模板没有命中，也可以返回结构检测框，作为更稳的 fallback。
- 如果模板命中但结构未命中，会记录日志并返回未检测到面板。

## 不包含

本 PR 不包含：
- 本地 fork 额外布局适配
- Coffee 自动化
- Gift 自动化
- 每日奖励领取新功能
- 环期/周期奖励领取
- fork 中完整的 Daily modular orchestrator
- runner framework
- full matrix
- assets、i18n、依赖、lock、config 或 packaging 改动

## 测试

已运行：

- `uv run python -m unittest tests.TestF1PanelDetector`：通过，4 项测试。
- `uv run python -m py_compile src\tasks\DailyTask.py src\tasks\F1PanelDetector.py tests\TestF1PanelDetector.py`：通过。
- `git diff --check upstream/main...HEAD`：通过。

覆盖场景：
- 16:9 下，“探索指南”式非每日页签亮起时，即使 `f1_activity_panel` 模板命中，也拒绝识别为每日活跃面板。
- 16:9 下，每日活跃页签选中且结构匹配时，接受模板命中。
- 16:9 下，结构匹配但模板未命中时，可返回结构检测框。
- open result 会保留明确失败原因。

## 本地验证产物

- `working/f1_panel_guard_20260514_162248/summary.json`

该产物使用合成帧验证 detector 行为，不触发真实游戏 UI 动作；结果只覆盖本 PR 范围内的 `native_16_9`：非每日页案例 `detected: false`，每日活跃页案例 `detected: true`。
