### PR TITLE
【自动粉爪路线B】添加重要的镜头设置要求提醒、优化大厅到办公层浔避战线路耗时

### DIFF
--- a/src/heist_path/HeistPathB.py
+++ b/src/heist_path/HeistPathB.py
@@ -48,9 +48,9 @@ class HeistPathB(HeistPathA):
         else:
             self.lg2_wp4_to_exit3()
 
-    # 全新大厅到LG1办公层线路，早雾控怪避战，理论正常11分00到办公层（实际耗时60s）
+    # 全新大厅到LG1办公层线路，早雾控怪避战，理论正常剩余11分00秒到办公层（实际耗时60s）
     def goto_lg1_skip_Sakiri(self):
-        self.log_round_info("大厅前往LG1")
+        self.log_round_info("早雾、大厅前往LG1")
         self.sleep(0.30)
         self.switch_to_runner(check_switched=True)
         self.sleep(0.10)
@@ -185,6 +185,7 @@ class HeistPathB(HeistPathA):
             if self.find_interac():
                 is_open_door = self.lobby_open_door_check()
                 if not is_open_door:
+                    from src.tasks.AutoHeistTask import AbortException
                     raise AbortException("timeout for wait_and_interact") # 考虑之后加复位或其他
                 else:
                     self.sleep(0.10)
@@ -196,9 +197,9 @@ class HeistPathB(HeistPathA):
         self.wait_and_interact(direction="w", is_lock=False, time_out=3.65)
         self.sleep(0.30)
 
-    # 全新大厅到LG1办公层线路，浔时停避战，理论正常11分12到办公层（实际耗时65s）
+    # 全新大厅到LG1办公层线路，浔时停避战，理论正常剩余11分15秒到办公层（实际耗时60s）
     def goto_lg1_skip_Hotori(self):
-        self.log_round_info("大厅前往LG1")
+        self.log_round_info("浔、大厅前往LG1")
         self.sleep(0.30)
         self.switch_to_avoider(check_switched=True)
         self.sleep(0.10)
@@ -245,13 +246,9 @@ class HeistPathB(HeistPathA):
         self.send_key('space', down_time=0.24)
         self.sleep(0.64)
         self.send_key('space', down_time=0.24)
-        self.sleep(0.64)
-        self.send_key('space', down_time=0.24)
-        self.sleep(0.64)
-        self.send_key('space', down_time=0.24)
-        self.sleep(0.64)
-        self.send_key('space', down_time=0.24)
-        self.sleep(0.64)
+        self.sleep(0.84)
+        self.send_key('lshift', down_time=0.24)
+        self.sleep(0.84)
         self.send_key_up("w")
         self.sleep(0.10)
         self.click(down_time=0.64)
@@ -303,19 +300,29 @@ class HeistPathB(HeistPathA):
         self.click(down_time=0.64)
         self.sleep(0.10)
         self.send_key_down('w')
-        self.sleep(5.14)
+        self.sleep(1.14)
+        self.send_key('lshift', down_time=0.24)
+        self.sleep(0.42)
+        self.send_key('lshift', down_time=0.24)
+        self.sleep(0.42)
+        self.send_key('lshift', down_time=0.24)
+        self.sleep(0.42)
         self.send_key_down("d")
-        self.sleep(0.36)
+        self.sleep(0.42)
         self.send_key_up('d')
-        self.sleep(3.60)
+        self.sleep(0.42)
+        self.send_key('lshift', down_time=0.24)
+        self.sleep(0.76)
         self.send_key_up('w')
         self.sleep(0.10)
         self.click(down_time=0.64)
+        self.sleep(0.10)
+        self.send_key_down('w')
         self.wait_and_interact(direction="w", is_lock=True, time_out=7.64)
         self.sleep(0.10)
         self.send_key_down("w")
         self.sleep(0.24)
-        self.send_key("a", down_time=0.36)
+        self.send_key("a", down_time=0.42)
         self.wait_and_interact(direction="w", is_lock=False, time_out=3.65)
         self.sleep(0.30)
 

--- a/src/tasks/AutoHeistTask.py
+++ b/src/tasks/AutoHeistTask.py
@@ -52,7 +52,10 @@ def _inst_gap():
 INST = "<br>".join(
     [
         _inst_line("📍 步骤起点：站在可互动小吱的位置开始", "#FF5555", bold=True),
-        _inst_line("⚙️ 镜头设置：控制 ➔ 移动镜头修正 ➔ 禁用", "#FF5555", bold=True),
+        _inst_line("⚙️ 镜头设置", "#FF5555", bold=True),
+        _inst_line("└─ 控制 ➔ 摄像机设置", "#FE821D", bold=True, indent=1),
+        _inst_line("├─ 移动镜头修正：禁用", "#FE821D", bold=True, indent=2),
+        _inst_line("└─ 按下锁定镜头回正：启用", "#FE821D", bold=True, indent=2),
         _inst_line("⚠️ 必备条件：至少有一个复活道具", "#FF5555", bold=True),
         _inst_line("🥷 避战方式：翳【长按 Shift】/ 浔【长按攻击】", "#FF5555", bold=True),
         _inst_gap(),
@@ -63,7 +66,6 @@ INST = "<br>".join(
         _inst_line("避战角色(可选): 翳 / 浔", indent=1),
         _inst_gap(),
         _inst_line("路径2推荐设置", bold=True),
-        _inst_line("⚙️ 镜头设置：控制 ➔ 摄像机设置 ➔ 按下锁定镜头回正 ➔ 启用", "#FF5555", bold=True, indent=1),
         _inst_line("画质：性能 | 分辨率: 1080P | FPS: 60 | 插帧: 关闭", indent=1),
         _inst_line("跑图角色: 薄荷", indent=1),
         _inst_line("早雾避战：", indent=1),

--- a/src/tasks/AutoHeistTask.py
+++ b/src/tasks/AutoHeistTask.py
@@ -63,7 +63,8 @@ INST = "<br>".join(
         _inst_line("避战角色(可选): 翳 / 浔", indent=1),
         _inst_gap(),
         _inst_line("路径2推荐设置", bold=True),
-        _inst_line("画质：性能 | 分辨率: 1080P | FPS: 60", indent=1),
+        _inst_line("⚙️ 镜头设置：控制 ➔ 摄像机设置 ➔ 按下锁定镜头回正 ➔ 启用", "#FF5555", bold=True, indent=1),
+        _inst_line("画质：性能 | 分辨率: 1080P | FPS: 60 | 插帧: 关闭", indent=1),
         _inst_line("跑图角色: 薄荷", indent=1),
         _inst_line("早雾避战：", indent=1),
         _inst_line(


### PR DESCRIPTION
1、添加重要的镜头设置要求提醒：⚙️ 镜头设置：控制 ➔ 摄像机设置 ➔ 按下锁定镜头回正 ➔ 启用
2、优化大厅到办公层浔避战线路耗时，所用时长缩短5秒，现在理论正常剩余11分15秒到办公层（实际耗时60s）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复门交互异常处理路径，确保异常分支可正确触发并继续流程；调整若干按键与等待节奏，提升路径执行稳定性与一致性（包含部分日志/提示文本更新以更准确反映流程）。

* **Documentation**
  * 优化自动任务配置指引：将镜头设置拆为分层步骤并新增“按下锁定镜头回正：启用”；在画质项中添加“插帧：关闭”。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->