### PR TITLE
fix(coffee): 补货不再被累计营业时间跳过 (#185)

### DIFF
--- a/src/coffee/runtime.py
+++ b/src/coffee/runtime.py
@@ -108,7 +108,6 @@ class CoffeeRuntime:
     COFFEE_PRODUCT_DEFAULT_SCAN_SCROLLS = 5
     COFFEE_SUPPLY_CLICK_SETTLE_SECONDS = 1.2
     COFFEE_SUPPLY_CLICK_DOWN_TIME = 0.04
-    COFFEE_RECENT_SUPPLY_SKIP_SECONDS = 30 * 60
     COFFEE_KEY_SETTLE_SECONDS = 1.0
     COFFEE_SUPPLY_BLOCKER_TEXTS = (
         "库存提示", "缺少", "方斯不足", "不足", "失败", "无法", "已满", "上限",
@@ -406,11 +405,6 @@ class CoffeeRuntime:
             self.actions.append("supply_already_completed_from_pending_confirm")
             return True, "", not self._dry_run()
 
-        active_seconds = self.current_business_seconds()
-        if self._recent_supply_active(active_seconds):
-            self.actions.append(f"supply_recently_active_not_needed:{active_seconds}")
-            return True, "supply_recently_active_not_needed", False
-
         supply_target = self.find_text_box("补货", self.COFFEE_LEFT_REGION)
         if supply_target is None:
             self.actions.append("supply_not_needed_or_not_found")
@@ -604,33 +598,6 @@ class CoffeeRuntime:
             return "未检测到送货上门确认按钮，未回到一咖舍界面，未验证补货成功"
         self.actions.append("supply_purchase_verified_without_delivery_prompt")
         return ""
-
-    def current_business_seconds(self):
-        texts = [self.box_text(box) for box in self.ocr_region(self.COFFEE_LEFT_REGION)]
-        if not any("累计营业时间" in text for text in texts):
-            return None
-        for text in texts:
-            match = re.search(r"(\d{1,2})[:：](\d{2})[:：](\d{2})", text)
-            if not match:
-                continue
-            hours, minutes, seconds = (int(part) for part in match.groups())
-            return hours * 3600 + minutes * 60 + seconds
-        return None
-
-    def _recent_supply_active(self, active_seconds):
-        if active_seconds is None or active_seconds <= 0:
-            return False
-        try:
-            threshold = int(
-                self._config_get(
-                    "coffee_recent_supply_skip_seconds",
-                    self.COFFEE_RECENT_SUPPLY_SKIP_SECONDS,
-                )
-                or 0
-            )
-        except (TypeError, ValueError):
-            threshold = self.COFFEE_RECENT_SUPPLY_SKIP_SECONDS
-        return threshold > 0 and active_seconds <= threshold
 
     def wait_for_supply_blocker_text(self, timeout=2):
         return self.wait_for(self.find_supply_blocker_text, timeout=timeout)

--- a/tests/TestCoffeeTask.py
+++ b/tests/TestCoffeeTask.py
@@ -52,18 +52,26 @@ class TestCoffeeRuntime(unittest.TestCase):
             [("鲜鱼套餐", 100), ("鲜鱼套餐", 120)],
         )
 
-    def test_recent_supply_no_op_evidence_is_preserved(self):
+    def test_replenish_supply_ignores_cumulative_business_time(self):
+        # Regression for issue #185: 累计营业时间 is reset when income is claimed, so a
+        # small cumulative time must NOT be read as "recently supplied". Even when the
+        # shop shows 00:05:00 and no 补货 button, replenish_supply proceeds to the 补货
+        # lookup (returning the safe no-op) instead of short-circuiting on business time.
+        # A legacy skip threshold left in config stays inert.
         task = _runtime_task({"coffee_recent_supply_skip_seconds": 1800})
+        task.ocr_ui = Mock(
+            return_value=[SimpleNamespace(text="累计营业时间 00:05:00", x=0, y=0, width=10, height=10)]
+        )
         runtime = CoffeeRuntime(task)
-        runtime.current_business_seconds = Mock(return_value=60)
-        runtime.find_text_box = Mock(side_effect=AssertionError("supply UI should not be touched for recent no-op"))
 
         ok, skip_reason, real_purchase = runtime.replenish_supply()
 
         self.assertTrue(ok)
         self.assertFalse(real_purchase)
-        self.assertEqual(skip_reason, "supply_recently_active_not_needed")
-        self.assertIn("supply_recently_active_not_needed:60", runtime.actions)
+        self.assertEqual(skip_reason, "supply_not_needed_or_not_found")
+        self.assertFalse(
+            any(action.startswith("supply_recently_active_not_needed") for action in runtime.actions)
+        )
 
     def test_runtime_falls_back_to_task_ocr_when_ocr_ui_absent(self):
         box = SimpleNamespace(text="一咖舍")
@@ -192,7 +200,6 @@ class TestCoffeeRuntime(unittest.TestCase):
         runtime.wait_for = Mock(return_value=True)
         runtime.claim_or_exit_coffee_challenge_result_if_present()
 
-        runtime.current_business_seconds = Mock(return_value=None)
         runtime.find_text_box = Mock(return_value=None)
 
         ok, skip_reason, real_purchase = runtime.replenish_supply()


### PR DESCRIPTION
领取收益会清零累计营业时间,而 `replenish_supply` 用它判定「近期已补货」跳过补货,且领收益恒在补货之前,导致补货永远不执行(未解锁自动补货的账号必现)。

移除该判定及仅供其使用的 `current_business_seconds` / `_recent_supply_active` 与常量,是否补货改由下游既有护栏(无「补货」按钮 / 库存已满)决定。回归用例已覆盖。

Fixes #185


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* 补货流程不再基于累计营业时间决定是否跳过采购操作。

## Tests
* 更新相关测试用例以验证补货流程的新行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->